### PR TITLE
Reconstruct template parameters

### DIFF
--- a/libdrgn/type.c
+++ b/libdrgn/type.c
@@ -697,8 +697,7 @@ drgn_compound_type_create(struct drgn_compound_type_builder *builder,
 				if (!string_builder_append(&full_tag, drgn_type_name(qtype.type)))
 					goto enomem;
 			} else {
-				// ooops
-				puts("No tage or name :(");
+				// TODO: What should we do?
 			}
 		}
 


### PR DESCRIPTION
Heavily templated code generates large amount of string to be stored in the `.debug_str` DWARF section. If the total size is above 4GiB, DWARF cannot address the strings beyond that limit and the linker might refuse to link the program. A solution is to use the compiler option `-gsimple-template-names`, which remove template parameters from the `DW_AT_name` of a type, if the full name can be reconstructed by using the template parameter names.

This PR add support for this option to drgn. If a type is templated, but its name doesn't contain the `<` character, we assume `-gsimple-template-names` was enabled and we need to reconstruct the full name.